### PR TITLE
Add: Claude automated PR review

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,0 +1,13 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, review_requested]
+
+jobs:
+  claude-review:
+    uses: EENCloud/workflow-library/.github/workflows/claude_auto_review.yml@main
+    secrets:
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+      VAULT_CA_CERT: ${{ secrets.VAULT_CA_CERT }}


### PR DESCRIPTION
Enrolls this repo in automated Claude PR reviews via the `claude_auto_review` reusable workflow in `workflow-library`.

Every PR will be reviewed by RobotEagle (Claude) automatically on open, when marked ready for review, or when a review is requested from RobotEagle. To request a re-review after new commits, tag `@claude` in a PR comment or re-request a review from RobotEagle.

## Before merging — Vault setup required

The workflow fetches the team's Anthropic API key from Vault. The key name is derived from the `ownerId` in `compass.yml`:

```bash

# Run this against the repo's compass.yml to find the Vault key name:

OWNER_ID=$(grep -m1 '^ownerId:' compass.yml | sed 's/^ownerId: *//' | tr -d '"' | xargs)

UUID=$(echo "$OWNER_ID" | sed 's/.*\///')

echo "team_$(echo "$UUID" | tr '-' '_')"
```

Ask a Vault admin to add the Anthropic API key at `secret/github/actions/claude` under that key name. If your team's key is already registered (another repo in the same team is already enrolled), no action is needed.

## Remove any existing Claude review workflows

If this repo already has a workflow that triggers Claude PR reviews (e.g. a `claude.yml` calling `claude_auto_review.yml`), **delete it when merging this PR**. Keeping both will cause every PR to receive two reviews.
