### PR TITLE
CODEOWNERS: owning team Events - OBC (263)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xtremerui
+* @xtremerui @EENCloud/events-obc-263


### PR DESCRIPTION
Ensures **docker-image-resource** has a CODEOWNERS file naming its owning team **Events - OBC (263)** (`@EENCloud/events-obc-263`).

**Changes:** update CODEOWNERS (appended team to existing '*' rule)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
